### PR TITLE
Add section blurbs for Posts and Notes

### DIFF
--- a/content/note/_index.md
+++ b/content/note/_index.md
@@ -3,4 +3,3 @@ title: "Notes"
 description: "Short notes and quick thoughts I want to keep around."
 ---
 
-Short notes and quick thoughts I want to keep around.

--- a/content/note/_index.md
+++ b/content/note/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Notes"
+description: "Short notes and quick thoughts I want to keep around."
+---
+
+Short notes and quick thoughts I want to keep around.

--- a/content/post/_index.md
+++ b/content/post/_index.md
@@ -1,6 +1,5 @@
 ---
 title: "Posts"
-description: "Longer-form posts about projects, data, and whatever I'm exploring."
+description: "Longer-form posts about whatever I'm exploring."
 ---
 
-Longer-form posts about projects, data, and whatever I'm exploring.

--- a/content/post/_index.md
+++ b/content/post/_index.md
@@ -1,0 +1,6 @@
+---
+title: "Posts"
+description: "Longer-form posts about projects, data, and whatever I'm exploring."
+---
+
+Longer-form posts about projects, data, and whatever I'm exploring.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -18,6 +18,11 @@
           <a class="home-pane-link" href="{{ .RelPermalink }}">All posts</a>
         {{ end }}
       </div>
+      {{ with $postsPage }}
+        {{ with .Params.description }}
+          <p class="home-pane-description">{{ . }}</p>
+        {{ end }}
+      {{ end }}
       <ul class="home-pane-list">
         {{ with $postsPage }}
           {{ range first 5 .Pages.ByDate.Reverse }}
@@ -60,6 +65,11 @@
           <a class="home-pane-link" href="{{ .RelPermalink }}">All notes</a>
         {{ end }}
       </div>
+      {{ with $notesPage }}
+        {{ with .Params.description }}
+          <p class="home-pane-description">{{ . }}</p>
+        {{ end }}
+      {{ end }}
       <ul class="home-pane-list">
         {{ with $notesPage }}
           {{ range first 5 .Pages.ByDate.Reverse }}

--- a/static/css/home-panes.css
+++ b/static/css/home-panes.css
@@ -55,6 +55,12 @@
   gap: 1rem;
 }
 
+.home-pane-description {
+  margin: 0 0 1rem;
+  font-size: 0.95rem;
+  color: var(--secondary, #a3a3a3);
+}
+
 .home-pane-item {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
### Motivation
- Show a short, regular-body-font blurb under the "Posts" and "Notes" headings on the home page for clarity and context.
- Make those mini descriptions available on the section listing pages as well so they appear at `/post/` and `/note/`.
- Provide placeholder text so the site has sensible defaults until custom content is added.

### Description
- Added `content/post/_index.md` and `content/note/_index.md` with front matter and placeholder description text to provide section-level blurbs.
- Updated `layouts/index.html` to render `.Params.description` under the `Posts` and `Notes` headers while keeping the existing cover/date/summary rendering and the `range first 5 .Pages.ByDate.Reverse` limit.
- Added a `.home-pane-description` rule to `static/css/home-panes.css` and included the stylesheet via `layouts/partials/extend_head.html` so the blurb uses the regular body font styling.

### Testing
- No automated site build or tests were run because the `hugo` binary is not available in the environment, so no automated verification was performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69504799d7c08333a68eee2aa04718a8)