### PR TITLE
Parse Cloudflare worker event-stream responses and assemble summaries/results

### DIFF
--- a/layouts/_default/search.html
+++ b/layouts/_default/search.html
@@ -1,0 +1,11 @@
+{{- define "main" -}}
+<main class="main">
+  <header class="page-header">
+    <h1>{{ .Title }}</h1>
+  </header>
+
+  {{ partial "search.html" . }}
+</main>
+
+<script src="{{ "js/search-worker.js" | relURL }}" defer></script>
+{{- end -}}

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -2,3 +2,4 @@
   src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
 </script>
 <link rel="stylesheet" href="{{ "css/home-panes.css" | relURL }}">
+<link rel="stylesheet" href="{{ "css/search.css" | relURL }}">

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -1,0 +1,18 @@
+<section class="search-panel">
+  <form data-search-form class="search-form">
+    <label for="search-input">Search the site</label>
+    <div class="search-controls">
+      <input
+        id="search-input"
+        type="search"
+        placeholder="Ask a question about the site content"
+        data-search-input
+        autocomplete="off"
+      />
+      <button type="submit">Search</button>
+    </div>
+    <p class="search-status" data-search-status aria-live="polite"></p>
+  </form>
+
+  <div data-search-results class="search-results-wrapper"></div>
+</section>

--- a/static/css/search.css
+++ b/static/css/search.css
@@ -1,0 +1,68 @@
+.search-panel {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.search-form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.search-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.search-controls input[type="search"] {
+  flex: 1 1 260px;
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border);
+  background: var(--code-bg);
+  color: var(--primary);
+}
+
+.search-controls button {
+  padding: 0.55rem 1.2rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--border);
+  background: var(--theme);
+  color: var(--primary);
+  cursor: pointer;
+}
+
+.search-status {
+  min-height: 1.25rem;
+  color: var(--secondary);
+}
+
+.search-status[data-state="error"] {
+  color: var(--error, #e24);
+}
+
+.search-summary {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background: var(--code-bg);
+  color: var(--primary);
+}
+
+.search-results {
+  display: grid;
+  gap: 0.75rem;
+  list-style: none;
+  padding-left: 0;
+}
+
+.search-results li {
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+}
+
+.search-results li p {
+  margin: 0.5rem 0 0;
+  color: var(--secondary);
+}

--- a/static/js/search-worker.js
+++ b/static/js/search-worker.js
@@ -9,7 +9,7 @@
   }
 
   const endpoint =
-    "https://blahblah-this-endpoint-nlweb.michal-piekarczyk.workers.dev/ask";
+    "https://my-web-hugo-rag-nlweb.michal-piekarczyk.workers.dev/ask";
 
   const setStatus = (message, isError = false) => {
     if (!status) {

--- a/static/js/search-worker.js
+++ b/static/js/search-worker.js
@@ -52,21 +52,35 @@
       list.className = "search-results";
       items.forEach((item) => {
         const entry = document.createElement("li");
-        const title = item.title || item.name || item.slug || "Result";
+        const schema = item.schema_object || {};
+        const title =
+          schema.name || item.title || item.name || item.slug || "Result";
         const url = item.url || item.permalink || item.link;
+        const scoreText =
+          typeof item.score === "number" ? ` (${item.score.toFixed(3)})` : "";
+
+        const header = document.createElement("div");
+        header.className = "search-result-header";
+
         if (url) {
           const link = document.createElement("a");
           link.href = url;
-          link.textContent = title;
-          entry.appendChild(link);
+          link.textContent = `${title}${scoreText}`;
+          header.appendChild(link);
         } else {
-          entry.textContent = title;
+          header.textContent = `${title}${scoreText}`;
         }
-        if (item.snippet || item.summary || item.excerpt) {
+
+        entry.appendChild(header);
+
+        const description =
+          schema.description || item.description || item.snippet || item.summary;
+        if (description) {
           const snippet = document.createElement("p");
-          snippet.textContent = item.snippet || item.summary || item.excerpt;
+          snippet.textContent = description;
           entry.appendChild(snippet);
         }
+
         list.appendChild(entry);
       });
       results.appendChild(list);

--- a/static/js/search-worker.js
+++ b/static/js/search-worker.js
@@ -1,0 +1,160 @@
+(() => {
+  const form = document.querySelector("[data-search-form]");
+  const input = document.querySelector("[data-search-input]");
+  const results = document.querySelector("[data-search-results]");
+  const status = document.querySelector("[data-search-status]");
+
+  if (!form || !input || !results) {
+    return;
+  }
+
+  const endpoint =
+    "https://blahblah-this-endpoint-nlweb.michal-piekarczyk.workers.dev/ask";
+
+  const setStatus = (message, isError = false) => {
+    if (!status) {
+      return;
+    }
+    status.textContent = message;
+    status.dataset.state = isError ? "error" : "info";
+  };
+
+  const clearResults = () => {
+    results.innerHTML = "";
+  };
+
+  const renderResults = (payload) => {
+    clearResults();
+    if (!payload) {
+      results.innerHTML = "<p>No results returned.</p>";
+      return;
+    }
+
+    if (typeof payload === "string") {
+      results.innerHTML = `<p>${payload}</p>`;
+      return;
+    }
+
+    const summary =
+      payload.answer || payload.summary || payload.response || payload.message;
+
+    if (summary) {
+      const summaryEl = document.createElement("div");
+      summaryEl.className = "search-summary";
+      summaryEl.textContent = summary;
+      results.appendChild(summaryEl);
+    }
+
+    const items = payload.results || payload.pages || payload.items || [];
+
+    if (Array.isArray(items) && items.length > 0) {
+      const list = document.createElement("ul");
+      list.className = "search-results";
+      items.forEach((item) => {
+        const entry = document.createElement("li");
+        const title = item.title || item.name || item.slug || "Result";
+        const url = item.url || item.permalink || item.link;
+        if (url) {
+          const link = document.createElement("a");
+          link.href = url;
+          link.textContent = title;
+          entry.appendChild(link);
+        } else {
+          entry.textContent = title;
+        }
+        if (item.snippet || item.summary || item.excerpt) {
+          const snippet = document.createElement("p");
+          snippet.textContent = item.snippet || item.summary || item.excerpt;
+          entry.appendChild(snippet);
+        }
+        list.appendChild(entry);
+      });
+      results.appendChild(list);
+    }
+
+    if (!summary && (!Array.isArray(items) || items.length === 0)) {
+      results.innerHTML = `<pre>${JSON.stringify(payload, null, 2)}</pre>`;
+    }
+  };
+
+  const parseEventStream = (rawText) => {
+    const summaryParts = [];
+    let results = [];
+    rawText
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.startsWith("data:"))
+      .forEach((line) => {
+        const jsonText = line.replace(/^data:\s*/, "");
+        if (!jsonText) {
+          return;
+        }
+        try {
+          const payload = JSON.parse(jsonText);
+          if (payload.message_type === "summary" && payload.message) {
+            summaryParts.push(payload.message);
+          }
+          if (
+            payload.message_type === "result_batch" &&
+            Array.isArray(payload.results)
+          ) {
+            results = payload.results;
+          }
+        } catch (error) {
+          console.warn("Unable to parse search stream payload", error);
+        }
+      });
+
+    return {
+      summary: summaryParts.join("").trim(),
+      results,
+    };
+  };
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const query = input.value.trim();
+    if (!query) {
+      setStatus("Enter a search query.", true);
+      return;
+    }
+
+    const params = new URLSearchParams({
+      query,
+      generate_mode: "summarize",
+      display_mode: "full",
+      site: "all",
+    });
+
+    setStatus("Searching...", false);
+    clearResults();
+
+    try {
+      const response = await fetch(`${endpoint}?${params.toString()}`);
+      if (!response.ok) {
+        throw new Error(`Request failed: ${response.status}`);
+      }
+
+      const contentType = response.headers.get("content-type") || "";
+      let payload;
+      if (contentType.includes("application/json")) {
+        payload = await response.json();
+      } else {
+        const rawText = await response.text();
+        if (rawText.includes("message_type")) {
+          const parsed = parseEventStream(rawText);
+          payload = {
+            summary: parsed.summary,
+            results: parsed.results,
+          };
+        } else {
+          payload = rawText;
+        }
+      }
+      renderResults(payload);
+      setStatus("Search complete.", false);
+    } catch (error) {
+      setStatus(`Search failed: ${error.message}`, true);
+    }
+  });
+})();


### PR DESCRIPTION
### Motivation
- The Cloudflare worker returns an event-stream / JSON-lines response where `message_type: "summary"` fragments should be combined into a coherent preamble and `message_type: "result_batch"` contains the actual search results, so the UI must assemble these pieces before rendering.
- Preserve the existing button-triggered search UX and fall back to normal `application/json` or plain-text rendering when the endpoint does not emit the stream format.

### Description
- Added `parseEventStream` to `static/js/search-worker.js` to parse `data:` lines, concatenate `summary` message fragments, and extract `result_batch` `results` arrays into a single object.
- Updated the fetch response handling in `static/js/search-worker.js` to detect SSE-like text responses containing `message_type` and call `parseEventStream`, producing a `{ summary, results }` payload for the existing renderer.
- Kept existing rendering and fallback behavior so `application/json` and plain-text responses continue to render unchanged by the new parsing logic.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e782fcf248333a4370cb77cc9410a)