### PR TITLE
Refocus README for public site and move maintainer notes

### DIFF
--- a/MAINTAINER_NOTES.md
+++ b/MAINTAINER_NOTES.md
@@ -1,0 +1,25 @@
+# Maintainer Notes
+
+These notes are for repository maintenance workflows.
+
+## Quickly convert blog post images to S3 artifacts
+
+This workflow expects `S3_DEPLOY_BUCKET` to be defined.
+
+### Upload images to S3 and append HTML links to an existing Markdown file
+
+```sh
+python quick_blog_post.py \
+    --append-only \
+    --existing-file "/path/to/content/file.md" \
+    --images "/full/path/to/image.png,/full/path/to/another_image.png"
+```
+
+### Convert local relative image links to S3 links and upload the images
+
+```sh
+python quick_blog_post.py \
+    --convert-images-to-s3-assets \
+    --existing-file "/path/to/content/file.md" \
+    --local-asset-dir "/path/to/local/asset/dir"
+```

--- a/README.md
+++ b/README.md
@@ -1,22 +1,28 @@
+# namoopsoo.github.io
 
+This repository contains the source for my public blog/site.
 
-### Quickly convert blog post images to S3 artifacts
-This code expects `S3_DEPLOY_BUCKET` is defined.
+## Tech stack
 
-## Examples
+- [Hugo](https://gohugo.io/) for static site generation
+- Theme content and custom layouts in this repository
 
-### upload images to s3 and append html links to them to an existing .md file
+## Local development
+
 ```sh
-python quick_blog_post.py \
-    --append-only \
-    --existing-file "/path/to/content/file.md" \
-    --images "/full/path/to/image.png,/full/path/to/another_image.png" \
+hugo server -D
 ```
 
-### convert local relative image links to s3 links and upload the images
+Then open `http://localhost:1313`.
+
+## Build
+
 ```sh
-python quick_blog_post.py \
-    --convert-images-to-s3-assets \
-    --existing-file "/path/to/content/file.md" \
-    --local-asset-dir "/path/to/local/asset/dir"
+hugo
 ```
+
+The generated site output is written to `public/`.
+
+## Maintainer notes
+
+Operational scripts and personal workflow notes have been moved out of this README into `MAINTAINER_NOTES.md`.


### PR DESCRIPTION
### Motivation

- Clean up the repository README to be public-facing and remove personal operational notes by relocating them to a separate maintainer document.
- Make it easier for contributors and visitors to get started by surfacing basic Hugo development and build commands.

### Description

- Rewrote `README.md` to describe the repository purpose, tech stack, and local development (`hugo server -D`) and build (`hugo`) instructions.
- Extracted the previous personal/operational `quick_blog_post.py` instructions into a new `MAINTAINER_NOTES.md` file and removed those details from `README.md`.
- Added and committed the updated `README.md` and the new `MAINTAINER_NOTES.md` to the repository.

### Testing

- Ran `git diff --check` after the changes and it completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998e190bee08333969876371c878c20)