### PR TITLE
Add configurable Giscus comments support for Hugo posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,16 @@ The generated site output is written to `public/`.
 ## Maintainer notes
 
 Operational scripts and personal workflow notes have been moved out of this README into `MAINTAINER_NOTES.md`.
+
+## Giscus comments setup
+
+This site includes optional support for [Giscus](https://giscus.app/) comments on post pages.
+
+1. Go to https://giscus.app/ and connect it to your repository discussions.
+2. Copy the generated values for repository + category IDs.
+3. Update `_config.toml` under `[params.giscus]`:
+   - set `enabled = true`
+   - set `repo`, `repoid`, and `categoryid`
+   - optionally adjust mapping/theme/language options
+
+When enabled, the comment widget is rendered below post content.

--- a/_config.toml
+++ b/_config.toml
@@ -41,3 +41,19 @@ unsafe = true
   site_logo = ""
   description = "The last theme you'll ever need. Maybe."
   custom_css = ["css/custom_code_style.css"]
+
+  [params.giscus]
+    enabled = false
+    repo = "" # e.g. "owner/repo"
+    repoid = "" # from giscus app
+    category = "Announcements"
+    categoryid = "" # from giscus app
+    mapping = "pathname"
+    strict = "0"
+    reactionsenabled = "1"
+    emitmetadata = "0"
+    inputposition = "bottom"
+    theme = "preferred_color_scheme"
+    lang = "en"
+    loading = "lazy"
+

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,0 +1,67 @@
+{{ define "header" }}
+   {{/* We can override any block in the baseof file be defining it in the template */}}
+  {{ partial "page-header.html" . }}
+{{ end }}
+
+{{ define "main" }}
+  {{ $section := .Site.GetPage "section" .Section }}
+  <article class="flex-l flex-wrap justify-between mw8 center ph3">
+    <header class="mt4 w-100">
+      <aside class="instapaper_ignoref b helvetica tracked">
+          {{/*
+          CurrentSection allows us to use the section title instead of inferring from the folder.
+          https://gohugo.io/variables/page/#section-variables-and-methods
+          */}}
+        {{with .CurrentSection.Title }}{{. | upper }}{{end}}
+      </aside>
+      {{ partial "social-share.html" . }}
+      <h1 class="f1 athelas mt3 mb1">
+        {{- .Title -}}
+      </h1>
+      {{ with .Params.author }}
+      <p class="tracked">
+          By <strong>
+          {{ if reflect.IsSlice . }}
+              {{ delimit . ", " | markdownify }}
+          {{else}}
+              {{ . | markdownify }}
+          {{ end }}
+          </strong>
+      </p>
+      {{ end }}
+      {{/* Hugo uses Go's date formatting is set by example. Here are two formats */}}
+      <time class="f6 mv4 dib tracked" {{ printf `datetime="%s"` (.Date.Format "2006-01-02T15:04:05Z07:00") | safeHTMLAttr }}>
+        {{- .Date.Format "January 2, 2006" -}}
+      </time>
+
+      {{/*
+          Show "reading time" and "word count" but only if one of the following are true:
+          1) A global config `params` value is set `show_reading_time = true`
+          2) A section front matter value is set `show_reading_time = true`
+          3) A page front matter value is set `show_reading_time = true`
+        */}}
+      {{ if (or (eq (.Param "show_reading_time") true) (eq $section.Params.show_reading_time true) )}}
+        <span class="f6 mv4 dib tracked"> - {{ .ReadingTime}} minutes read</span>
+        <span class="f6 mv4 dib tracked"> - {{ .WordCount}} words</span>
+      {{ end }}
+    </header>
+    <div class="nested-copy-line-height lh-copy {{ $.Param "post_content_classes"  | default "serif"}} f4 nested-links nested-img mid-gray pr4-l w-two-thirds-l">
+      {{- .Content -}}
+      {{- partial "tags.html" . -}}
+      <div class="mt6 instapaper_ignoref">
+      {{ if .Site.DisqusShortname }}
+        {{ template "_internal/disqus.html" . }}
+      {{ end }}
+      {{ if .Site.Params.commentoEnable }}
+        {{- partial "commento.html" . -}}
+      {{ end }}
+      {{- partial "giscus.html" . -}}
+      </div>
+    </div>
+
+    <aside class="w-30-l mt6-l">
+      {{- partial "menu-contextual.html" . -}}
+    </aside>
+
+  </article>
+{{ end }}

--- a/layouts/partials/giscus.html
+++ b/layouts/partials/giscus.html
@@ -1,0 +1,22 @@
+{{- $giscus := .Site.Params.giscus -}}
+{{- if and $giscus.enabled $giscus.repo $giscus.repoid $giscus.category $giscus.categoryid -}}
+<div class="mt5">
+  <script
+    src="https://giscus.app/client.js"
+    data-repo="{{ $giscus.repo }}"
+    data-repo-id="{{ $giscus.repoid }}"
+    data-category="{{ $giscus.category }}"
+    data-category-id="{{ $giscus.categoryid }}"
+    data-mapping="{{ $giscus.mapping | default "pathname" }}"
+    data-strict="{{ $giscus.strict | default "0" }}"
+    data-reactions-enabled="{{ $giscus.reactionsenabled | default "1" }}"
+    data-emit-metadata="{{ $giscus.emitmetadata | default "0" }}"
+    data-input-position="{{ $giscus.inputposition | default "bottom" }}"
+    data-theme="{{ $giscus.theme | default "preferred_color_scheme" }}"
+    data-lang="{{ $giscus.lang | default .Site.Language.Lang }}"
+    data-loading="{{ $giscus.loading | default "lazy" }}"
+    crossorigin="anonymous"
+    async
+  ></script>
+</div>
+{{- end -}}


### PR DESCRIPTION
### Motivation
- Provide optional GitHub Discussions–backed comments (Giscus) for post pages so site maintainers can use repository discussions instead of or in addition to Disqus/Commento. 
- Keep the integration opt-in and configurable via site parameters to avoid altering behavior unless explicitly enabled.

### Description
- Add `layouts/partials/giscus.html`, a partial that renders the official Giscus script only when required `[params.giscus]` fields are present and `enabled = true`.
- Override the post single template with `layouts/_default/single.html` to include the new Giscus partial in the existing comments area alongside Disqus and Commento integrations.
- Add a `[params.giscus]` configuration block to `_config.toml` with sensible defaults and placeholders for `repo`, `repoid`, `categoryid`, and other widget options.
- Document setup and enabling steps in `README.md` under a new "Giscus comments setup" section.

### Testing
- Attempted to run `hugo` to build the site, but the command failed in this environment because Hugo is not installed (`bash: command not found: hugo`).
- No other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998e569f538833393eae96e01e1c9df)