### PR TITLE
feat: add Giscus comments support for Hugo site

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -39,7 +39,19 @@ params:
   UseHugoToc: true
   disableSpecial1stPost: false
   disableScrollToTop: false
-  comments: false
+  comments: true
+  giscus:
+    repo: namoopsoo/namoopsoo.github.io
+    repoId: R_kgDOH6TH1A
+    category: General
+    categoryId: DIC_kwDOH6TH1M4Cf6Vh
+    mapping: pathname
+    strict: "0"
+    reactionsEnabled: "1"
+    emitMetadata: "0"
+    inputPosition: top
+    lang: en
+    theme: preferred_color_scheme
   hidemeta: false
   hideSummary: false
   ShowToc: true

--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,0 +1,29 @@
+{{- /*
+Giscus comments for PaperMod.
+Configure under params.giscus in config.yaml.
+*/ -}}
+{{- if and .Site.Params.comments .Site.Params.giscus -}}
+  {{- $giscus := .Site.Params.giscus -}}
+  {{- if and $giscus.repo $giscus.repoId $giscus.category $giscus.categoryId -}}
+<div class="giscus-comments">
+  <script
+    src="https://giscus.app/client.js"
+    data-repo="{{ $giscus.repo }}"
+    data-repo-id="{{ $giscus.repoId }}"
+    data-category="{{ $giscus.category }}"
+    data-category-id="{{ $giscus.categoryId }}"
+    data-mapping="{{ $giscus.mapping | default "pathname" }}"
+    data-strict="{{ $giscus.strict | default "0" }}"
+    data-reactions-enabled="{{ $giscus.reactionsEnabled | default "1" }}"
+    data-emit-metadata="{{ $giscus.emitMetadata | default "0" }}"
+    data-input-position="{{ $giscus.inputPosition | default "top" }}"
+    data-theme="{{ $giscus.theme | default "preferred_color_scheme" }}"
+    data-lang="{{ $giscus.lang | default "en" }}"
+    crossorigin="anonymous"
+    async>
+  </script>
+</div>
+  {{- else -}}
+<!-- giscus is enabled, but required params are missing: repo, repoId, category, categoryId -->
+  {{- end -}}
+{{- end -}}


### PR DESCRIPTION
### Motivation
- Add GitHub Discussions–backed commenting (Giscus) to the Hugo site so posts can accept comments via a GitHub Discussions category.
- Provide a configurable, theme-friendly partial and site params so comments can be enabled/disabled and tuned from `config.yaml`.

### Description
- Enable site comments and add a `params.giscus` configuration block in `config.yaml` with `repo`, `repoId`, `category`, `categoryId`, `mapping`, `strict`, `reactionsEnabled`, `emitMetadata`, `inputPosition`, `lang`, and `theme` settings.
- Add `layouts/partials/comments.html` which conditionally renders the Giscus embed (`https://giscus.app/client.js`) when `Site.Params.comments` and required `params.giscus` keys are present.
- The partial uses sensible defaults for optional attributes so the embed is configurable but safe when some optional fields are omitted.

### Testing
- Ran `hugo --panicOnWarning` which failed due to an existing unrelated missing layout error and is therefore not a blocker for the Giscus changes.
- Ran `hugo` which completed successfully with warnings unrelated to Giscus.
- Ran `hugo server` which started and served the site locally, and captured a screenshot via a Playwright script to validate the running site.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a59051b9883338a859aa97dd32377)